### PR TITLE
fix failed mijin connection error

### DIFF
--- a/src/infrastructure/HttpEndpoint.ts
+++ b/src/infrastructure/HttpEndpoint.ts
@@ -89,6 +89,8 @@ export abstract class HttpEndpoint {
       this.historicalNodes = [
         {protocol: "http", domain: "88.99.192.82", port: 7890},
       ];
+    } else if (NEMLibrary.getNetworkType() === NetworkTypes.MIJIN_NET) {
+      this.historicalNodes = this.nodes;
     } else {
       throw new Error("Nodes uninitialized");
     }


### PR DESCRIPTION
I fixed mijin connection error.

When NetworkTyeps set MIJIN_NET, throw the  error `Node uninitialized`
I decided to set `nodes` to `historicalNodes` so that an error does not occur.
